### PR TITLE
Communication devel

### DIFF
--- a/communication/refbox_comm/src/refBoxUtils.cpp
+++ b/communication/refbox_comm/src/refBoxUtils.cpp
@@ -51,15 +51,6 @@ comm_msg::GameState llsf2ros_gameState(const llsf_msgs::GameState &llsfGameState
     case llsf_msgs::GameState::POST_GAME:
         rosGameState.phase = comm_msg::GameState::POST_GAME;
         break;
-    case llsf_msgs::GameState::OPEN_CHALLENGE:
-        rosGameState.phase = comm_msg::GameState::OPEN_CHALLENGE;
-        break;
-    case llsf_msgs::GameState::NAVIGATION_CHALLENGE:
-        rosGameState.phase = comm_msg::GameState::NAVIGATION_CHALLENGE;
-        break;
-    case llsf_msgs::GameState::WHACK_A_MOLE_CHALLENGE:
-        rosGameState.phase = comm_msg::GameState::WHACK_A_MOLE_CHALLENGE;
-        break;
     }
 
     rosGameState.points = ((team_color == llsf_msgs::Team::CYAN) ?
@@ -123,7 +114,6 @@ comm_msg::MachineInfo llsf2ros_machineInfo(const llsf_msgs::MachineInfo &llsfMac
         rosMachine.type = machine.type();
         rosMachine.state = machine.state();
         rosMachine.team_color = machine.team_color();
-        rosMachine.prepared = machine.prepared();
         rosMachine.pose.x = machine.pose().x();
         rosMachine.pose.y = machine.pose().y();
         rosMachine.pose.theta = machine.pose().ori();

--- a/messages/comm_msg/msg/GameState.msg
+++ b/messages/comm_msg/msg/GameState.msg
@@ -13,11 +13,7 @@ uint16 EXPLORATION = 20
 uint16 PRODUCTION  = 30
 uint16 POST_GAME   = 40
 
-uint16 OPEN_CHALLENGE         = 1000
-uint16 NAVIGATION_CHALLENGE   = 1001
-uint16 WHACK_A_MOLE_CHALLENGE = 1002
 
 uint16 phase
 
 uint32 points
-

--- a/messages/comm_msg/msg/Machine.msg
+++ b/messages/comm_msg/msg/Machine.msg
@@ -12,7 +12,6 @@ string type
 string state
 uint8 team_color
 
-bool prepared
 
 LightSpec[] lights
 geometry_msgs/Pose2D pose


### PR DESCRIPTION
Mise à jour du noeud refBox_comm pour suivre les modifications de la refbox officielle, toujours sur la branche timn/rcll-2015
- Suppression des phases concernant les challenges (dans le message GameState)
- Suppression d'un booléen indiquant les machines préparées (dans le message Machine)
