### PR TITLE
Work/valentin/artag/correctif

### DIFF
--- a/hardware/tf_broadcaster/src/tf_broadcaster.cpp
+++ b/hardware/tf_broadcaster/src/tf_broadcaster.cpp
@@ -2,53 +2,63 @@
 
 void poseCallback(const nav_msgs::Odometry &odom)
 {
-    static tf::TransformBroadcaster mapToOdom;
-    static tf::TransformBroadcaster odomToBaseLink;
-    static tf::TransformBroadcaster baseLinkToLaserLink;
-    static tf::TransformBroadcaster baseLinkToTowerCameraLink;
-    static tf::TransformBroadcaster baseLinkToPlatformCameraLink;
-    static ros::NodeHandle nh;
+	static tf::TransformBroadcaster mapToOdom;
+	static tf::TransformBroadcaster odomToBaseLink;
+	static tf::TransformBroadcaster baseLinkToLaserLink;
+	static tf::TransformBroadcaster baseLinkToTowerCameraLink;
+	static tf::TransformBroadcaster baseLinkToPlatformCameraLink;
+	static ros::NodeHandle nh;
 
-    std::string tf_prefix;
-    nh.param<std::string>("simuRobotNamespace", tf_prefix, "");;
-    if (tf_prefix.size() != 0)
-        tf_prefix += "/";
+	std::string tf_prefix;
+	nh.param<std::string>("simuRobotNamespace", tf_prefix, "");;
+	if (tf_prefix.size() != 0)
+		tf_prefix += "/";
 
-    // Map to odom
-    tf::Transform transform;
-    transform.setOrigin(tf::Vector3(0.0, 0.0, 0.0));
-    tf::Quaternion q;
-    q.setRPY(0.0, 0.0, 0.0);
-    transform.setRotation(q);
-    mapToOdom.sendTransform(tf::StampedTransform(transform, odom.header.stamp, "map", tf_prefix+"odom"));
+	// Map to odom
+	tf::Transform transform;
+	transform.setOrigin(tf::Vector3(0.0, 0.0, 0.0));
+	tf::Quaternion q;
+	q.setRPY(0.0, 0.0, 0.0);
+	transform.setRotation(q);
+	mapToOdom.sendTransform(tf::StampedTransform(transform, odom.header.stamp, "map", tf_prefix+"odom"));
 
-    // Odom to Base Link
-    transform.setOrigin(tf::Vector3(odom.pose.pose.position.x, odom.pose.pose.position.y, 0.0));
-    tf::quaternionMsgToTF(odom.pose.pose.orientation, q);
-    transform.setRotation(q);
-    odomToBaseLink.sendTransform(tf::StampedTransform(transform, odom.header.stamp, tf_prefix+"odom", tf_prefix+"base_link"));
+	// Odom to Base Link
+	transform.setOrigin(tf::Vector3(odom.pose.pose.position.x, odom.pose.pose.position.y, 0.0));
+	tf::quaternionMsgToTF(odom.pose.pose.orientation, q);
+	transform.setRotation(q);
+	odomToBaseLink.sendTransform(tf::StampedTransform(transform, odom.header.stamp, tf_prefix+"odom", tf_prefix+"base_link"));
 
-    // Base Link to Laser Link
-    static double laser_link_x = 0;
-    nh.param<double>("hardware/robotDescription/baseLink_to_laserLink/x", laser_link_x, 0.10);
-    transform.setOrigin(tf::Vector3(laser_link_x, 0.0, 0.232));
-    q.setRPY(0.0, 0.0, 0.0);
-    transform.setRotation(q);
-    baseLinkToLaserLink.sendTransform(tf::StampedTransform(transform, odom.header.stamp, tf_prefix+"base_link", tf_prefix+"laser_link"));
+	// Base Link to Laser Link
+	static double laser_link_x = 0;
+	nh.param<double>("hardware/robotDescription/baseLink_to_laserLink/x", laser_link_x, 0.10);
+	transform.setOrigin(tf::Vector3(laser_link_x, 0.0, 0.232));
+	q.setRPY(0.0, 0.0, 0.0);
+	transform.setRotation(q);
+	baseLinkToLaserLink.sendTransform(tf::StampedTransform(transform, odom.header.stamp, tf_prefix+"base_link", tf_prefix+"laser_link"));
 
-    // Base Link to Tower Camera Link
-    static double tower_camera_link_z = 0;
-    nh.param<double>("hardware/robotDescription/baseLink_to_towerCameraLink/z", tower_camera_link_z, 0.60);
-    transform.setOrigin(tf::Vector3(0.2, 0.0, tower_camera_link_z));
-    q.setRPY(0.0, 0.0, 0.0);
-    transform.setRotation(q);
-    baseLinkToTowerCameraLink.sendTransform(tf::StampedTransform(transform, odom.header.stamp, tf_prefix+"base_link", tf_prefix+"tower_camera_link"));
+	// Base Link to Tower Camera Link
+	static double tower_camera_link_x = 0;
+	static double tower_camera_link_y = 0;
+	static double tower_camera_link_z = 0;
+	nh.param<double>("hardware/robotDescription/baseLink_to_towerCameraLink/x", tower_camera_link_x, 0.20);
+	nh.param<double>("hardware/robotDescription/baseLink_to_towerCameraLink/y", tower_camera_link_y, 0.00);
+	nh.param<double>("hardware/robotDescription/baseLink_to_towerCameraLink/z", tower_camera_link_z, 0.60);
+	transform.setOrigin(tf::Vector3(tower_camera_link_x, tower_camera_link_y, tower_camera_link_z));
+	q.setRPY(-1.57, 0, -1.57);
+	transform.setRotation(q);
+	baseLinkToTowerCameraLink.sendTransform(tf::StampedTransform(transform, odom.header.stamp
+		, tf_prefix+"base_link", tf_prefix+"tower_camera_link"));
 
-    // Base Link to Platform Camera Link
-    static double platform_camera_link_z = 0;
-    nh.param<double>("hardware/robotDescription/baseLink_to_platformCameraLink/z", platform_camera_link_z, 0.90);
-    transform.setOrigin(tf::Vector3(0.0, 0.0, platform_camera_link_z));
-    q.setRPY(0.0, 0.0, 0.0);
-    transform.setRotation(q);
-    baseLinkToPlatformCameraLink.sendTransform(tf::StampedTransform(transform, odom.header.stamp, tf_prefix+"base_link", tf_prefix+"platform_camera_link"));
+	// Base Link to Platform Camera Link
+	static double platform_camera_link_x = 0;
+	static double platform_camera_link_y = 0;
+	static double platform_camera_link_z = 0;
+	nh.param<double>("hardware/robotDescription/baseLink_to_platformCameraLink/x", platform_camera_link_x, 0.0);
+	nh.param<double>("hardware/robotDescription/baseLink_to_platformCameraLink/y", platform_camera_link_y, 0.00);
+	nh.param<double>("hardware/robotDescription/baseLink_to_platformCameraLink/z", platform_camera_link_z, 0.90);
+	transform.setOrigin(tf::Vector3(platform_camera_link_x, platform_camera_link_y, platform_camera_link_z));
+	q.setRPY(0.0, 0.0, -1.57);
+	transform.setRotation(q);
+	baseLinkToPlatformCameraLink.sendTransform(tf::StampedTransform(transform, odom.header.stamp
+		, tf_prefix+"base_link", tf_prefix+"platform_camera_link"));
 }

--- a/hardware/tf_broadcaster/src/tf_broadcaster.cpp
+++ b/hardware/tf_broadcaster/src/tf_broadcaster.cpp
@@ -57,7 +57,7 @@ void poseCallback(const nav_msgs::Odometry &odom)
 	nh.param<double>("hardware/robotDescription/baseLink_to_platformCameraLink/y", platform_camera_link_y, 0.00);
 	nh.param<double>("hardware/robotDescription/baseLink_to_platformCameraLink/z", platform_camera_link_z, 0.90);
 	transform.setOrigin(tf::Vector3(platform_camera_link_x, platform_camera_link_y, platform_camera_link_z));
-	q.setRPY(0.0, 0.0, -1.57);
+	q.setRPY(-1.57, 0, -1.57);
 	transform.setRotation(q);
 	baseLinkToPlatformCameraLink.sendTransform(tf::StampedTransform(transform, odom.header.stamp
 		, tf_prefix+"base_link", tf_prefix+"platform_camera_link"));

--- a/navigation/approche_finale/src/arTagFA.cpp
+++ b/navigation/approche_finale/src/arTagFA.cpp
@@ -41,7 +41,7 @@ void ArTagFA::artagCallback(const ar_track_alvar_msgs::AlvarMarkers::ConstPtr& m
 
 ArTagFA::ArTagFA()
 {
-	m_arTagSub = m_nh.subscribe("computerVision/ar_pose_marker",1000,&ArTagFA::artagCallback,this);        
+	m_arTagSub = m_nh.subscribe("ar_pose_marker",1000,&ArTagFA::artagCallback,this);        
 }
 
 std::vector<int> ArTagFA::getId()

--- a/navigation/approche_finale/src/finalApproaching.cpp
+++ b/navigation/approche_finale/src/finalApproaching.cpp
@@ -89,6 +89,7 @@ void finalApproaching::executeCB(const manager_msg::finalApproachingGoalConstPtr
 		{
 			usefulInfo = true;
 		}
+		loopRate.sleep();
 	}
 	//loop to find a correct ARTag
 	std::vector<int> allPossibleId = idWanted(teamColor,0/*gameState.getPhase()*/);
@@ -112,6 +113,7 @@ void finalApproaching::executeCB(const manager_msg::finalApproachingGoalConstPtr
 		float newOrientation = odom.getOrientationZ()-initOrientation;
 		phase = phaseDependingOnOrientation(newOrientation,phase);
 		m_pubMvt.publish(msgTwist);
+		loopRate.sleep();
 	}
 	//lock loop with ARTag camera 
 	while(ros::ok() && !bp.getState() && phase!=3 && avancementArTag==0 && obstacle==false)
@@ -134,6 +136,7 @@ void finalApproaching::executeCB(const manager_msg::finalApproachingGoalConstPtr
 		}
 		allObstacles = sharps.getObstacle();
 		obstacle = false;//obstacleDetection(allObstacles, k, oz, pz);
+		loopRate.sleep();
 	}
 	ROS_INFO("Waiting a complete laserscan");
 	//lock loop with laserscan
@@ -217,8 +220,8 @@ void finalApproaching::executeCB(const manager_msg::finalApproachingGoalConstPtr
 				as.publishFeedback(feedback);
 				ros::spinOnce();
 				ROS_DEBUG("etat du bumper: %d ",bp.getState());
-				loopRate.sleep();
 			}
+			loopRate.sleep();
 		}
 	}
 	//reinitialisation

--- a/navigation/path_tracker/scripts/path_tracker_test_node.py
+++ b/navigation/path_tracker/scripts/path_tracker_test_node.py
@@ -275,7 +275,7 @@ def callbackOdom(data):
         #orienation finale
         (lastRoll, lastPitch, lastYaw) = euler_from_quaternion_msg(g_path[-1].pose.orientation)
         err = normalizeAngle(lastYaw - pose.theta)
-        if (abs(err) < 0.01):
+        if (abs(err) < 0.05):
             g_pathFinished = True
         else:
             cmdVel_msg.angular.z = g_anglePID.update(err)

--- a/simulation/gazebo_sim_launch/launch/test.launch
+++ b/simulation/gazebo_sim_launch/launch/test.launch
@@ -68,7 +68,8 @@
 		<node pkg="path_tracker" name="path_tracker_node" type="path_tracker_test_node.py"/>
 
 			<!-- Load the fake final approach -->
-			<node pkg="approche_finale" name="final_approach" type="simFinalApproach_node"/>
+			<!--<node pkg="approche_finale" name="final_approach" type="simFinalApproach_node"/>-->
+			<node pkg="approche_finale" name="final_approach" type="finalApproaching_node"/>
 			<!-- <node pkg="approche_finale" name="final_approach" type="simFinalApproach_node" launch-prefix="xterm -e"/> -->
 
 			<!-- Load the navigation manager -->

--- a/simulation/gazebo_sim_launch/worlds/field2015_sixRobots.world
+++ b/simulation/gazebo_sim_launch/worlds/field2015_sixRobots.world
@@ -73,7 +73,7 @@
 			<static>true</static>
 
 			<link name="top_camera_link">
-				<pose>0 2.5 8 0 1.57 1.57</pose>
+				<pose>0 2.5 100 0 1.57 1.57</pose>
 
 				<gravity>false</gravity>
 
@@ -99,7 +99,7 @@
 				<sensor type="camera" name="top_camera">
 					<update_rate>30.0</update_rate>
 					<camera name="top_camera">
-						<horizontal_fov>1.3962634</horizontal_fov>
+						<horizontal_fov>0.13</horizontal_fov>
 						<image>
 							<width>1200</width>
 							<height>700</height>

--- a/simulation/gazebo_sim_launch/worlds/test.world
+++ b/simulation/gazebo_sim_launch/worlds/test.world
@@ -31,12 +31,13 @@
 
 
 
+
 		<!-- Top camera (for supervision) -->
 		<model name="top_camera">
 			<static>true</static>
 
 			<link name="top_camera_link">
-				<pose>0 2.5 8 0 1.57 1.57</pose>
+				<pose>0 2.5 100 0 1.57 1.57</pose>
 
 				<gravity>false</gravity>
 
@@ -62,7 +63,7 @@
 				<sensor type="camera" name="top_camera">
 					<update_rate>30.0</update_rate>
 					<camera name="top_camera">
-						<horizontal_fov>1.3962634</horizontal_fov>
+						<horizontal_fov>0.13</horizontal_fov>
 						<image>
 							<width>1200</width>
 							<height>700</height>

--- a/simulation/gazebo_to_ros/src/gazebo_to_ros_node.cpp
+++ b/simulation/gazebo_to_ros/src/gazebo_to_ros_node.cpp
@@ -16,6 +16,8 @@
 #include <tf/transform_datatypes.h>
 
 double g_x, g_y, g_z;
+/* TODO: Find better solution */
+bool g_init = false;
 ros::Publisher g_pubOdom;
 ros::Publisher g_pubLightSignal;
 ros::Publisher g_pubMachines;
@@ -35,96 +37,98 @@ void machineInfoCallback(ModelStatesConstPtr &msg);
 /////////////////////////////////////////////////
 int main(int argc, char **argv)
 {
-    printf("Gazebo to ros Started\n");
-    // Load gazebo
-    gazebo::setupClient(argc, argv);
+	printf("Gazebo to ros Started\n");
+	// Load gazebo
+	gazebo::setupClient(argc, argv);
 
-    // Create our node for communication
-    gazebo::transport::NodePtr node(new gazebo::transport::Node());
-    node->Init();
-    ros::init(argc, argv, "publisher");
-    ros::NodeHandle nh;
-    std::string robotName;
-    nh.param<std::string>("simuRobotNamespace", robotName, ROBOTINO_NAME);
+	// Create our node for communication
+	gazebo::transport::NodePtr node(new gazebo::transport::Node());
+	node->Init();
+	ros::init(argc, argv, "publisher");
+	ros::NodeHandle nh;
+	std::string robotName;
+	nh.param<std::string>("simuRobotNamespace", robotName, ROBOTINO_NAME);
 
-    // Publish to a Gazebo topic
-    gazebo::transport::PublisherPtr pub =
-        // node->Advertise<gazebo::msgs::Vector3d>("/gazebo/pyro_2015/robotino_pyro/RobotinoSim/MotorMove/");
-        node->Advertise<gazebo::msgs::Vector3d>("/gazebo/pyro_2015/" +robotName+ "/RobotinoSim/MotorMove/");
+	// Publish to a Gazebo topic
+	gazebo::transport::PublisherPtr pub =
+		// node->Advertise<gazebo::msgs::Vector3d>("/gazebo/pyro_2015/robotino_pyro/RobotinoSim/MotorMove/");
+		node->Advertise<gazebo::msgs::Vector3d>("/gazebo/pyro_2015/" +robotName+ "/RobotinoSim/MotorMove/");
 
-    // Wait for a subscriber to connect
-    pub->WaitForConnection();
+	// Wait for a subscriber to connect
+	pub->WaitForConnection();
 
-    // Subscriber
-    ros::Subscriber subCmdVel = nh.subscribe("hardware/cmd_vel", 1, &cmdVelCallback);
-    ros::Subscriber subModelStates = nh.subscribe("/gazebo/model_states", 1, &machineInfoCallback);
-    g_pubOdom = nh.advertise<nav_msgs::Odometry>("hardware/odom", 1000);
-    gazebo::transport::SubscriberPtr subGps = node->Subscribe("/gazebo/pyro_2015/" +robotName+ "/gazsim/gps/", &gpsCallback);
-    gazebo::transport::SubscriberPtr subLightSignal = node->Subscribe("/gazebo/pyro_2015/" +robotName+ "/gazsim/light-signal/", &lightSignalCallback);
+	// Subscriber
+	ros::Subscriber subCmdVel = nh.subscribe("hardware/cmd_vel", 1, &cmdVelCallback);
+	ros::Subscriber subModelStates = nh.subscribe("/gazebo/model_states", 1, &machineInfoCallback);
+	g_pubOdom = nh.advertise<nav_msgs::Odometry>("hardware/odom", 1000);
+	gazebo::transport::SubscriberPtr subGps = node->Subscribe("/gazebo/pyro_2015/" +robotName+ "/gazsim/gps/", &gpsCallback);
+	gazebo::transport::SubscriberPtr subLightSignal = node->Subscribe("/gazebo/pyro_2015/" +robotName+ "/gazsim/light-signal/", &lightSignalCallback);
 	// Publisher
 	g_pubLightSignal = nh.advertise<trait_im_msg::LightSignal>("hardware/closest_light_signal", 1000);
-    g_pubMachines = nh.advertise<deplacement_msg::Landmarks>("objectDetection/landmarks", 1000, true);
+	g_pubMachines = nh.advertise<deplacement_msg::Landmarks>("objectDetection/landmarks", 1000, true);
+	g_init = true;
 
-    // Publisher loop...replace with your own code.
-    g_x=0; g_y=0; g_z=0;
-    gazebo::math::Vector3 vect(g_x,g_y,g_z);
-    while (ros::ok())
-    {
-        // Throttle Publication
-        gazebo::common::Time::MSleep(100);
+	// Publisher loop...replace with your own code.
+	g_x=0; g_y=0; g_z=0;
+	gazebo::math::Vector3 vect(g_x,g_y,g_z);
+	while (ros::ok())
+	{
+		// Throttle Publication
+		gazebo::common::Time::MSleep(100);
 
-        // Generate a pose
-        vect.Set(g_x, g_y, g_z);
+		// Generate a pose
+		vect.Set(g_x, g_y, g_z);
 
-        // Convert to a pose message
-        gazebo::msgs::Vector3d msg;
-        gazebo::msgs::Set(&msg, vect);
+		// Convert to a pose message
+		gazebo::msgs::Vector3d msg;
+		gazebo::msgs::Set(&msg, vect);
 
-        pub->Publish(msg);
-        ros::spinOnce();
-    }
+		pub->Publish(msg);
+		ros::spinOnce();
+	}
 
-    // Make sure to shut everything down.
-    gazebo::shutdown();
+	// Make sure to shut everything down.
+	gazebo::shutdown();
 }
 
 void cmdVelCallback(const geometry_msgs::TwistConstPtr& msg)
 {
-    g_x=msg->linear.x;
-    g_y=msg->linear.y;
-    g_z=msg->angular.z;
+	g_x=msg->linear.x;
+	g_y=msg->linear.y;
+	g_z=msg->angular.z;
 }
 
 void gpsCallback(ConstPosePtr &msg)
 {
-    ros::NodeHandle nh;
-    std::string tf_prefix;
-    nh.param<std::string>("simuRobotNamespace", tf_prefix, "");;
-    if (tf_prefix.size() != 0)
-        tf_prefix += "/";
+	ros::NodeHandle nh;
+	std::string tf_prefix;
+	nh.param<std::string>("simuRobotNamespace", tf_prefix, "");;
+	if (tf_prefix.size() != 0)
+		tf_prefix += "/";
 
-    nav_msgs::Odometry odom_msg;
-    odom_msg.child_frame_id=tf_prefix+"base_link";
-    odom_msg.header.frame_id=tf_prefix+"odom";
-    odom_msg.header.stamp=ros::Time::now();
+	nav_msgs::Odometry odom_msg;
+	odom_msg.child_frame_id=tf_prefix+"base_link";
+	odom_msg.header.frame_id=tf_prefix+"odom";
+	odom_msg.header.stamp=ros::Time::now();
 
-    odom_msg.pose.pose.position.x=msg->position().x();
-    odom_msg.pose.pose.position.y=msg->position().y();
-    odom_msg.pose.pose.position.z=0;
+	odom_msg.pose.pose.position.x=msg->position().x();
+	odom_msg.pose.pose.position.y=msg->position().y();
+	odom_msg.pose.pose.position.z=0;
 
-    odom_msg.pose.pose.orientation.x=msg->orientation().x();
-    odom_msg.pose.pose.orientation.y=msg->orientation().y();
-    odom_msg.pose.pose.orientation.z=msg->orientation().z();
-    odom_msg.pose.pose.orientation.w=msg->orientation().w();
+	odom_msg.pose.pose.orientation.x=msg->orientation().x();
+	odom_msg.pose.pose.orientation.y=msg->orientation().y();
+	odom_msg.pose.pose.orientation.z=msg->orientation().z();
+	odom_msg.pose.pose.orientation.w=msg->orientation().w();
 
-    odom_msg.twist.twist.linear.x=g_x;
-    odom_msg.twist.twist.linear.y=g_y;
-    odom_msg.twist.twist.linear.z=0;
-    odom_msg.twist.twist.angular.x=0;
-    odom_msg.twist.twist.angular.y=0;
-    odom_msg.twist.twist.angular.z=g_z;
+	odom_msg.twist.twist.linear.x=g_x;
+	odom_msg.twist.twist.linear.y=g_y;
+	odom_msg.twist.twist.linear.z=0;
+	odom_msg.twist.twist.angular.x=0;
+	odom_msg.twist.twist.angular.y=0;
+	odom_msg.twist.twist.angular.z=g_z;
 
-    g_pubOdom.publish(odom_msg);
+	if (g_init)
+		g_pubOdom.publish(odom_msg);
 }
 
 
@@ -140,40 +144,42 @@ void lightSignalCallback(ConstLightSignalDetectionPtr &msg)
 		lightSignals_msg.lights.push_back(lightSpec_msg);
 	}
 
-	g_pubLightSignal.publish(lightSignals_msg);
+	if (g_init)
+		g_pubLightSignal.publish(lightSignals_msg);
 }
 
 void machineInfoCallback(ModelStatesConstPtr &msg)
 {
-    ros::NodeHandle nh;
-    bool useMachineInfo = false;
-    nh.param<bool>("objectDetection/useSimLandmarks", useMachineInfo, false);
+	ros::NodeHandle nh;
+	bool useMachineInfo = false;
+	nh.param<bool>("objectDetection/useSimLandmarks", useMachineInfo, false);
 
-    printf("MachineInfo Callback\n");
-    if (!useMachineInfo)
-        return;
+	printf("MachineInfo Callback\n");
+	if (!useMachineInfo)
+		return;
 
-    g_landmarks.header.stamp = ros::Time::now();
-    g_landmarks.header.frame_id = "map";
+	g_landmarks.header.stamp = ros::Time::now();
+	g_landmarks.header.frame_id = "map";
 
-    // go through all machines
-    g_landmarks.landmarks.clear();
-    for(int i = 0; i < msg->name.size(); i++){
+	// go through all machines
+	g_landmarks.landmarks.clear();
+	for(int i = 0; i < msg->name.size(); i++){
 
-        if (msg->name[i][0] != 'C' && msg->name[i][0] != 'M')
-        {
-            continue;
-        }
+		if (msg->name[i][0] != 'C' && msg->name[i][0] != 'M')
+		{
+			continue;
+		}
 
-        geometry_msgs::Pose2D pose;
-        pose.x = msg->pose[i].position.x;
-        pose.y = msg->pose[i].position.y;
-        pose.theta = tf::getYaw(msg->pose[i].orientation);
+		geometry_msgs::Pose2D pose;
+		pose.x = msg->pose[i].position.x;
+		pose.y = msg->pose[i].position.y;
+		pose.theta = tf::getYaw(msg->pose[i].orientation);
 
-        g_landmarks.landmarks.push_back(pose);
-    }
+		g_landmarks.landmarks.push_back(pose);
+	}
 
-    g_pubMachines.publish(g_landmarks);
+	if (g_init)
+		g_pubMachines.publish(g_landmarks);
 
-    return;
+	return;
 }

--- a/traitement_image/ar_tag/launch/alvar_simu.launch
+++ b/traitement_image/ar_tag/launch/alvar_simu.launch
@@ -1,5 +1,5 @@
 <launch>
-        <arg name="marker_size" default="4.4" />
+        <arg name="marker_size" default="13.5" />
         <arg name="max_new_marker_error" default="0.08" />
         <arg name="max_track_error" default="0.2" />
         <arg name="cam_image_topic" default="hardware/camera/tower_camera/image_raw" />


### PR DESCRIPTION
#### Description du problème

Sur simulation, `ar_track_alvar` retournait des positions délirantes pour les `ar_tag`. On pensait que le calibrage était en cause, mais par défaut les caméras simulés n'ont pas de distorsion.  
Le problème provenait de deux choses :  
1. Le repère de la caméra était mal orienté. Il faut que l'axe `z` pointe en direction de l'objectif, `x` vers la droite de l'image et `y` vers le bas de l'image. C'est corrigé dans `tf_broadcaster` pour _tower_camera_ et _platform_camera_.
2. En simulation, la camera était mal placée. Elle était 20cm à gauche au lieu de 20cm en avant, ce qui était en désaccord avec la transformation `tf`. C'est corrigé dans `gazebo_rcll` pour tous les robotinos pyros.
#### Modifications autres
- La _top_camera_ qui permet d'avoir un aperçu de la simulation est maintenant placée à 100m de haut mais avec un angle de vue minuscule. Ça évite la perspective parfois gênante quand le robot passe derrière une machine.
- Intégration du commit de Cyril, avec une correction sur un nom de topic et ajout des loop_rate.sleep() sur plusieurs boucles de l'approche finale.
- Des modifications d'indentations ... désolé :neutral_face:

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pyroteam/robocup-pkg/57)

<!-- Reviewable:end -->
