### PR TITLE
Ar_track_alvar et les frame tf (et tf_prefix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 robocup-pkg
 ===========
 [![Build Status](https://travis-ci.org/PyroTeam/robocup-pkg.svg?branch=devel)](https://travis-ci.org/PyroTeam/robocup-pkg)
+

--- a/hardware/tf_broadcaster/src/tf_broadcaster.cpp
+++ b/hardware/tf_broadcaster/src/tf_broadcaster.cpp
@@ -10,7 +10,7 @@ void poseCallback(const nav_msgs::Odometry &odom)
 	static ros::NodeHandle nh;
 
 	std::string tf_prefix;
-	nh.param<std::string>("simuRobotNamespace", tf_prefix, "");;
+	nh.param<std::string>("simuRobotNamespace", tf_prefix, "");
 	if (tf_prefix.size() != 0)
 		tf_prefix += "/";
 

--- a/navigation/final_approach/src/ArTagFA.cpp
+++ b/navigation/final_approach/src/ArTagFA.cpp
@@ -19,6 +19,21 @@ void ArTagFA::artagCallback(const ar_track_alvar_msgs::AlvarMarkers::ConstPtr& m
 
 	if(!msg->markers.empty())
 	{
+		std::string tf_prefix;
+		m_nh.param<std::string>("simuRobotNamespace", tf_prefix, "");
+		if (tf_prefix.size() != 0)
+			tf_prefix += "/";
+
+		// Garantie, violemment, que l'on travaille avec les bonnes informations
+		// En l'attente du changement de repère adequat, les positions ARTag doivent être publiées
+		// dans le bon repère, à savoir le repère tower_camera_link du robot
+		//
+		// Je vous l'accorde, c'est du brutal
+		if (msg->markers.front().header.frame_id.compare(tf_prefix+"tower_camera_link") != 0)
+		{
+			assert(!"ARTag markers MUST be published in robotino_ns/tower_camera_link frame");
+		}
+
 		for(int i = 0; i < msg->markers.size(); i++)
 		{
 			arTag_t arTag;

--- a/navigation/final_approach/src/ar_tag_reader_node.cpp
+++ b/navigation/final_approach/src/ar_tag_reader_node.cpp
@@ -10,7 +10,7 @@ float orientationZ = 0;
 void artagCallback(const ar_track_alvar_msgs::AlvarMarkers::ConstPtr& msg)
 {
 	geometry_msgs::Twist msgTwist;
-	if(msg->markers.size()!=0) 
+	if(msg->markers.size()!=0)
 	{
    		ROS_INFO("I see: [%d]", msg->markers[0].id);
 		float px = msg->markers[0].pose.pose.position.x;

--- a/simulation/gazebo_sim_launch/launch/env_finalApproach.launch
+++ b/simulation/gazebo_sim_launch/launch/env_finalApproach.launch
@@ -23,13 +23,14 @@
 	</group>
 	<!-- Robotino Pyro 1 -->
 	<group ns="robotino1">
+		<arg name="tf_prefix" value="robotino1"/>
 
 		<!-- Params -->
 		<param name="teamName" value="PYRO" />
 		<param name="teamColor" value="cyan" />
 		<param name="robotNumber" value="1" />
 		<param name="robotName" value="R1" />
-		<param name="simuRobotNamespace" value="robotino1" />
+		<param name="simuRobotNamespace" value="$(arg tf_prefix)" />
 
 		<rosparam file="$(find gazebo_sim_launch)/param/robotino1_navigation.yaml" />
 
@@ -52,15 +53,11 @@
 		<node pkg="feu_tricolore" name="simLightDetection" type="sim_light_detection"/>
 
 		<!-- Load ArTag -->
-		<!-- <include file="$(find ar_tag)/launch/alvar_simu.launch"/> -->
-        <arg name="marker_size" default="13.5" />
-        <arg name="max_new_marker_error" default="0.08" />
-        <arg name="max_track_error" default="0.2" />
-        <arg name="cam_image_topic" default="hardware/camera/tower_camera/image_raw" />
-        <arg name="cam_info_topic" default="hardware/camera/tower_camera/camera_info" />
-        <arg name="output_frame" default="robotino1/tower_camera_link" />
-
-        <node name="ar_track_alvar" pkg="ar_track_alvar" type="individualMarkersNoKinect" respawn="false" output="screen" args="$(arg marker_size) $(arg max_new_marker_error) $(arg max_track_error) $(arg cam_image_topic) $(arg cam_info_topic) $(arg output_frame)" />
+		<include file="$(find ar_tag)/launch/alvar_simu.launch">
+			<arg name="output_frame" value="$(arg tf_prefix)/tower_camera_link"/>
+			<arg name="respawn" value="true"/>
+			<arg name="output" value="log"/>
+		</include>
 
 		<include file="$(find ar_tag)/launch/ar_tag.launch"/>
 	</group>

--- a/simulation/gazebo_sim_launch/launch/test.launch
+++ b/simulation/gazebo_sim_launch/launch/test.launch
@@ -25,11 +25,13 @@
 	</group>
 	<!-- Robotino Pyro 1 -->
 	<group ns="robotino1">
+		<arg name="tf_prefix" value="robotino1"/>
+
 		<param name="teamName" value="PYRO" />
 		<param name="teamColor" value="magenta" />
 		<param name="robotNumber" value="1" />
 		<param name="robotName" value="R1" />
-		<param name="simuRobotNamespace" value="robotino1" />
+		<param name="simuRobotNamespace" value="$(arg tf_prefix)" />
 
 		<!-- Load the gazebo_to_ros node -->
 		<arg name="debug_gazebo_to_tos" value="false" />
@@ -46,7 +48,11 @@
 				<node pkg="feu_tricolore" name="simLightDetection" type="sim_light_detection"/>
 
 				<!-- Load ArTag -->
-				<include file="$(find ar_tag)/launch/alvar_simu.launch"/>
+				<include file="$(find ar_tag)/launch/alvar_simu.launch">
+					<arg name="output_frame" value="$(arg tf_prefix)/tower_camera_link"/>
+					<arg name="respawn" value="true"/>
+					<arg name="output" value="log"/>
+				</include>
 				<include file="$(find ar_tag)/launch/ar_tag.launch"/>
 
 				<!-- Load the objectDetections nodes -->

--- a/simulation/gazebo_sim_launch/launch/test_finalApproach.launch
+++ b/simulation/gazebo_sim_launch/launch/test_finalApproach.launch
@@ -21,13 +21,14 @@
 	</group>
 	<!-- Robotino Pyro 1 -->
 	<group ns="robotino1">
+		<arg name="tf_prefix" value="robotino1"/>
 
 		<!-- Params -->
 		<param name="teamName" value="PYRO" />
 		<param name="teamColor" value="cyan" />
 		<param name="robotNumber" value="1" />
 		<param name="robotName" value="R1" />
-		<param name="simuRobotNamespace" value="robotino1" />
+		<param name="simuRobotNamespace" value="$(arg tf_prefix)" />
 
 		<!-- Robot description -->
 		<param name="robot_description" textfile="$(find robotino_description)/urdf/robotino3_pyro.urdf" />
@@ -48,15 +49,11 @@
 		<node pkg="feu_tricolore" name="simLightDetection" type="sim_light_detection"/>
 
 		<!-- Load ArTag -->
-		<!-- <include file="$(find ar_tag)/launch/alvar_simu.launch"/> -->
-        <arg name="marker_size" default="13.5" />
-        <arg name="max_new_marker_error" default="0.08" />
-        <arg name="max_track_error" default="0.2" />
-        <arg name="cam_image_topic" default="hardware/camera/tower_camera/image_raw" />
-        <arg name="cam_info_topic" default="hardware/camera/tower_camera/camera_info" />
-        <arg name="output_frame" default="robotino1/tower_camera_link" />
-
-        <node name="ar_track_alvar" pkg="ar_track_alvar" type="individualMarkersNoKinect" respawn="false" output="screen" args="$(arg marker_size) $(arg max_new_marker_error) $(arg max_track_error) $(arg cam_image_topic) $(arg cam_info_topic) $(arg output_frame)" />
+		<include file="$(find ar_tag)/launch/alvar_simu.launch">
+			<arg name="output_frame" value="$(arg tf_prefix)/tower_camera_link"/>
+			<arg name="respawn" value="true"/>
+			<arg name="output" value="log"/>
+		</include>
 
 		<include file="$(find ar_tag)/launch/ar_tag.launch"/>
 

--- a/traitement_image/ar_tag/launch/alvar_simu.launch
+++ b/traitement_image/ar_tag/launch/alvar_simu.launch
@@ -4,8 +4,13 @@
         <arg name="max_track_error" default="0.2" />
         <arg name="cam_image_topic" default="hardware/camera/tower_camera/image_raw" />
         <arg name="cam_info_topic" default="hardware/camera/tower_camera/camera_info" />
-        <arg name="output_frame" default="map" />
+        <arg name="output_frame" default="tower_camera_link" />
+        <arg name="output" default="screen" />
+        <arg name="respawn" default="false" />
 
-        <node name="ar_track_alvar" pkg="ar_track_alvar" type="individualMarkersNoKinect" respawn="false" output="screen" args="$(arg marker_size) $(arg max_new_marker_error) $(arg max_track_error) $(arg cam_image_topic) $(arg cam_info_topic) $(arg output_frame)" />
+        <node name="ar_track_alvar" pkg="ar_track_alvar" type="individualMarkersNoKinect"
+        	respawn="$(arg respawn)" output="$(arg output)"
+        	args="$(arg marker_size) $(arg max_new_marker_error) $(arg max_track_error)
+        	$(arg cam_image_topic) $(arg cam_info_topic) $(arg output_frame)" />
 
 </launch>


### PR DESCRIPTION
Lié à issue : https://github.com/PyroTeam/robocup-pkg/issues/66

J'ai modifié des launchfiles de simu pour que ar_track_alvar soit en conformité vis à vis de nos namespaces.
Un gros assert a aussi été ajouté sur l'approche finale pour s'assurer qu'on bosse avec le bon repère en guise de solution de contournement.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyroteam/robocup-pkg/67)

<!-- Reviewable:end -->
